### PR TITLE
Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
  - pypy
- - pypy3
+ - pypy-3.8
  - 2.7
  - 3.6
  - 3.5


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos